### PR TITLE
Made selected vierkand readable in dark mode

### DIFF
--- a/resources/js/Components/Vierkandle/Vierkand.vue
+++ b/resources/js/Components/Vierkandle/Vierkand.vue
@@ -12,7 +12,7 @@ defineProps<{
 
 <template>
 <div class="relative rounded-lg vierkand transition-all"
-     :class="`${(start == 0 && includes == 0) ? 'used' : ''} ${active ? 'shadow-2xl border-4 border-red-500 bg-white' : 'bg-gray-300 dark:bg-gray-900'}`">
+     :class="`${(start == 0 && includes == 0) ? 'used' : ''} ${active ? 'shadow-2xl border-4 border-red-500 bg-transparent' : 'bg-gray-300 dark:bg-gray-900'}`">
     <div class="letter">
         {{ letter }}
     </div>


### PR DESCRIPTION
# Made selected vierkand readable in dark mode

The Vierkand component wasn't readable when it was active/selected in dark mode as shown in the image below.
![image](https://github.com/JonaMata/Bambuzzle/assets/36168589/1d14b8b4-acf1-4c9f-9409-88b9e0dbce27)
This has been fixed by changing the background to transparent when selected. This is the result:
![image](https://github.com/JonaMata/Bambuzzle/assets/36168589/af48a117-a994-4600-bae1-3abc2f590647)
